### PR TITLE
build query with with optional filter parameter by adding '!' sign at…

### DIFF
--- a/query.go
+++ b/query.go
@@ -82,7 +82,10 @@ func (q *Query) Where() (string, []interface{}) {
 				wheres = append(wheres, columnName+` `+opr+` ?`)
 				args = append(args, v)
 			}
+		} else {
+			wheres = append(wheres, ` 1 = 1 `)
 		}
+
 	}
 	return strings.Join(wheres, " AND "), args
 }


### PR DESCRIPTION
build query with with optional filter parameter by adding '!' sign at the end of arg
i.e : 

valueStatus = "" or  nil
with require sign parameter ("!")
```
"status$eq!"   ~> `where status = '' `
```
without require sign parameter ("!")
will generate as  "true" condition
```
"status$eq" ~> `where 1 =1`
```